### PR TITLE
Accessibility violations should make tests fail explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,5 +77,4 @@ There are several packages that can enhance your large-scale applications, but a
 ## Future features to add to this app
 In the future, we will add:
 - Demonstrate nested route / paginated requests according to ember best practices
-- Improve a11y testing (currently runs during acceptance tests, but does not cause tests to fail; 
-  see [known pending issue](https://github.com/ember-a11y/ember-a11y-testing/issues/47))
+

--- a/bower.json
+++ b/bower.json
@@ -12,8 +12,5 @@
     "bootstrap-sass": "^3.3.6",
     "raven-js": "~3.3",
     "toastr": "^2.1.2"
-  },
-  "devDependencies": {
-    "axe-core": "~2.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bootstrap-sass": "3.3.7",
     "broccoli-asset-rev": "^2.4.2",
     "coveralls": "^2.11.15",
-    "ember-a11y-testing": "0.1.6",
+    "ember-a11y-testing": "^0.2.0",
     "ember-ajax": "^2.0.1",
     "ember-bootstrap": "1.0.0-alpha.3",
     "ember-cli": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ember-data": "^2.8.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
-    "ember-osf": "git+https://github.com/CenterForOpenScience/ember-osf.git#6bd19bf5112cb89e49de99481a1189d72906e162",
+    "ember-osf": "~0.2.0",
     "ember-page-title": "3.1.5",
     "ember-resolver": "^2.0.3",
     "ember-welcome-page": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bootstrap-sass": "3.3.7",
     "broccoli-asset-rev": "^2.4.2",
     "coveralls": "^2.11.15",
-    "ember-a11y-testing": "^0.2.0",
+    "ember-a11y-testing": "0.2.0",
     "ember-ajax": "^2.0.1",
     "ember-bootstrap": "1.0.0-alpha.3",
     "ember-cli": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bootstrap-sass": "3.3.7",
     "broccoli-asset-rev": "^2.4.2",
     "coveralls": "^2.11.15",
-    "ember-a11y-testing": "0.2.0",
+    "ember-a11y-testing": "0.2.1",
     "ember-ajax": "^2.0.1",
     "ember-bootstrap": "1.0.0-alpha.3",
     "ember-cli": "2.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1678,9 +1678,9 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-ember-a11y-testing@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-0.2.0.tgz#55132cba6597647bd375459e66ba30f42ef6c306"
+ember-a11y-testing@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-0.2.1.tgz#06d4123ca2f9de857dd41b5062142249bf9a178f"
   dependencies:
     axe-core "~2.1.7"
     broccoli-funnel "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1316,21 +1316,13 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@1.5.0:
+concat-stream@1.5.0, concat-stream@^1.4.6, concat-stream@^1.4.7:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.5.0.tgz#53f7d43c51c5e43f81c8fdd03321c631be68d611"
   dependencies:
     inherits "~2.0.1"
     readable-stream "~2.0.0"
     typedarray "~0.0.5"
-
-concat-stream@^1.4.6, concat-stream@^1.4.7:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
-  dependencies:
-    inherits "^2.0.3"
-    readable-stream "^2.2.2"
-    typedarray "^0.0.6"
 
 config-chain@~1.1.10:
   version "1.1.11"
@@ -2199,9 +2191,9 @@ ember-moment@6.1.0:
   dependencies:
     ember-cli-babel "^5.1.6"
 
-"ember-osf@git+https://github.com/CenterForOpenScience/ember-osf.git#6bd19bf5112cb89e49de99481a1189d72906e162":
-  version "0.1.0"
-  resolved "git+https://github.com/CenterForOpenScience/ember-osf.git#6bd19bf5112cb89e49de99481a1189d72906e162"
+ember-osf@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ember-osf/-/ember-osf-0.2.0.tgz#7b3ab441d6d66059b0c503fe5db4c5e564077b54"
   dependencies:
     broccoli-funnel "^1.0.1"
     broccoli-merge-trees "^1.1.1"
@@ -3168,7 +3160,7 @@ glob@3.x:
     inherits "2"
     minimatch "0.3"
 
-glob@7.0.5, glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@~7.0.3:
+glob@7.0.5, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@~7.0.3:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.5.tgz#b4202a69099bbb4d292a7c1b95b6682b67ebdc95"
   dependencies:
@@ -3199,7 +3191,7 @@ glob@^6.0.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.1, glob@~7.1.1:
+glob@^7.0.0, glob@^7.1.1, glob@~7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -3505,7 +3497,7 @@ inherit@^2.2.2:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/inherit/-/inherit-2.2.6.tgz#f1614b06c8544e8128e4229c86347db73ad9788d"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -5366,7 +5358,7 @@ read@1, read@1.0.x, read@~1.0.1, read@~1.0.7:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@~2.1.2:
+"readable-stream@1 || 2", readable-stream@^2, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@~2.1.2:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
   dependencies:
@@ -5386,18 +5378,6 @@ readable-stream@1.1:
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
-
-"readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.1, readable-stream@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
-  dependencies:
-    buffer-shims "^1.0.0"
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
-    util-deprecate "~1.0.1"
 
 readable-stream@~1.0.2:
   version "1.0.34"
@@ -5544,7 +5524,32 @@ request-progress@~2.0.1:
   dependencies:
     throttleit "^1.0.0"
 
-request@2, request@2.75.0, request@^2.27.0, request@^2.47.0, request@^2.61.0:
+request@2, request@^2.27.0, request@^2.47.0, request@^2.61.0, request@~2.79.0:
+  version "2.79.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
+  dependencies:
+    aws-sign2 "~0.6.0"
+    aws4 "^1.2.1"
+    caseless "~0.11.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.0"
+    forever-agent "~0.6.1"
+    form-data "~2.1.1"
+    har-validator "~2.0.6"
+    hawk "~3.1.3"
+    http-signature "~1.1.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.7"
+    oauth-sign "~0.8.1"
+    qs "~6.3.0"
+    stringstream "~0.0.4"
+    tough-cookie "~2.3.0"
+    tunnel-agent "~0.4.1"
+    uuid "^3.0.0"
+
+request@2.75.0:
   version "2.75.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.75.0.tgz#d2b8268a286da13eaa5d01adf5d18cc90f657d93"
   dependencies:
@@ -5614,31 +5619,6 @@ request@~2.72.0:
     stringstream "~0.0.4"
     tough-cookie "~2.2.0"
     tunnel-agent "~0.4.1"
-
-request@~2.79.0:
-  version "2.79.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
-  dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.11.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~2.0.6"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    qs "~6.3.0"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "~0.4.1"
-    uuid "^3.0.0"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -6359,7 +6339,7 @@ type-is@~1.6.10, type-is@~1.6.13, type-is@~1.6.14:
     media-typer "0.3.0"
     mime-types "~2.1.13"
 
-typedarray@^0.0.6, typedarray@~0.0.5:
+typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -266,6 +266,10 @@ aws4@^1.2.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.5.0.tgz#0a29ffb79c31c9e712eeb087e8e7a64b4a56d755"
 
+axe-core@~2.1.7:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.1.7.tgz#4f66f2b3ee3b58ec2d3db4339dd124c5b33b79c3"
+
 babel-core@^5.0.0, babel-core@^5.8.38, babel-core@~5.8.3:
   version "5.8.38"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-5.8.38.tgz#1fcaee79d7e61b750b00b8e54f6dfc9d0af86558"
@@ -596,7 +600,7 @@ broccoli-asset-rewrite@^1.1.0:
   dependencies:
     broccoli-filter "^1.2.3"
 
-broccoli-babel-transpiler@^5.4.5, broccoli-babel-transpiler@^5.5.0, broccoli-babel-transpiler@^5.6.0, broccoli-babel-transpiler@^5.6.1:
+broccoli-babel-transpiler@^5.4.5, broccoli-babel-transpiler@^5.5.0, broccoli-babel-transpiler@^5.6.0, broccoli-babel-transpiler@^5.6.1, broccoli-babel-transpiler@^5.6.2:
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.6.2.tgz#958c72e43575b2f0a862a5096dba1ce1ebc7d74d"
   dependencies:
@@ -722,7 +726,7 @@ broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
 
-broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.2, broccoli-funnel@^1.0.3:
+broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.2, broccoli-funnel@^1.0.3, broccoli-funnel@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.1.0.tgz#dfb91a37c902456456de4a40a1881948d65b27d9"
   dependencies:
@@ -1674,13 +1678,14 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-ember-a11y-testing@0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-0.1.6.tgz#69ebd054318b1f59745040fb923b4f7df3200a99"
+ember-a11y-testing@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-0.2.0.tgz#55132cba6597647bd375459e66ba30f42ef6c306"
   dependencies:
-    broccoli-funnel "^1.0.1"
-    ember-cli-babel "^5.1.6"
-    ember-cli-version-checker "^1.1.6"
+    axe-core "~2.1.7"
+    broccoli-funnel "^1.1.0"
+    ember-cli-babel "^5.2.4"
+    ember-cli-version-checker "^1.2.0"
 
 ember-ajax@^2.0.1:
   version "2.5.4"
@@ -1724,6 +1729,16 @@ ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.10, ember-cli-babel@^5.1.3, ember-c
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.1.tgz#14a1a7b3ae9e9f1284f7bcdb142eb53bd0b1b5bd"
   dependencies:
     broccoli-babel-transpiler "^5.6.0"
+    broccoli-funnel "^1.0.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^1.0.2"
+    resolve "^1.1.2"
+
+ember-cli-babel@^5.2.4:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz#5ce4f46b08ed6f6d21e878619fb689719d6e8e13"
+  dependencies:
+    broccoli-babel-transpiler "^5.6.2"
     broccoli-funnel "^1.0.0"
     clone "^2.0.0"
     ember-cli-version-checker "^1.0.2"


### PR DESCRIPTION
# Purpose
Make sure that unit tests fail and report errors if the page has accessibility violations - no more staring at the dev console and wondering.

# Summary of changes
Upgrade to ember-a11y 0.2.0 to take advantage of a new feature.

# Testing notes
I am presently having trouble visiting the login page with this new version; I get console errors about axe being undefined. Hold as a reminder until this is addressed. There may be weird interactions with the very newest release.

