### PR TITLE
[EOSF-554] Update to Node.js version 8

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/boron
+8

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - ./node_modules/phantomjs-prebuilt/bin/phantomjs --version
 
 install:
-  - yarn install --pure-lockfile
+  - yarn install --pure-lockfile --ignore-engines
   - ./node_modules/bower/bin/bower install --config.interactive=false
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:boron
+FROM node:8
 
 RUN apt-get update \
     && apt-get install -y \
@@ -40,7 +40,7 @@ RUN mkdir -p /code
 WORKDIR /code
 
 COPY ./package.json ./yarn.lock /code/
-RUN yarn --pure-lockfile
+RUN yarn --pure-lockfile --ignore-engines
 
 COPY ./.bowerrc /code/.bowerrc
 COPY ./bower.json /code/bower.json

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "repository": "",
   "engineStrict": true,
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "author": "Center for Open Science",
   "license": "Apache-2.0",


### PR DESCRIPTION
Related:
* CenterForOpenScience/osf.io#7350
* CenterForOpenScience/ember-osf#225

## Ticket
https://openscience.atlassian.net/browse/EOSF-554

# Purpose
Updates Node.js version to 8

# Summary of changes
Remove lts/boron and replace it with 8 everywhere, and add --ignore-engines due to  qunitjs/qunit#1184.

# Testing notes
This should not affect any functionality, normal regression only.